### PR TITLE
Fix merge_sort.py code bug

### DIFF
--- a/examples/control_flow/control_flow/merge_sort.py
+++ b/examples/control_flow/control_flow/merge_sort.py
@@ -31,11 +31,12 @@ seed(datetime.now().microsecond)
 
 # %%
 @task
-def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int]:
+def split(numbers: typing.List[int]) -> Tuple[typing.List[int], typing.List[int], int, int]:
     return (
         numbers[0 : int(len(numbers) / 2)],
         numbers[int(len(numbers) / 2) :],
         int(len(numbers) / 2),
+        int(len(numbers)) - int(len(numbers) / 2),
     )
 
 
@@ -80,9 +81,9 @@ def sort_locally(numbers: typing.List[int]) -> typing.List[int]:
 # %%
 @dynamic
 def merge_sort_remotely(numbers: typing.List[int], run_local_at_count: int) -> typing.List[int]:
-    split1, split2, new_count = split(numbers=numbers)
-    sorted1 = merge_sort(numbers=split1, numbers_count=new_count, run_local_at_count=run_local_at_count)
-    sorted2 = merge_sort(numbers=split2, numbers_count=new_count, run_local_at_count=run_local_at_count)
+    split1, split2, new_count1, new_count2 = split(numbers=numbers)
+    sorted1 = merge_sort(numbers=split1, numbers_count=new_count1, run_local_at_count=run_local_at_count)
+    sorted2 = merge_sort(numbers=split2, numbers_count=new_count2, run_local_at_count=run_local_at_count)
     return merge(sorted_list1=sorted1, sorted_list2=sorted2)
 
 


### PR DESCRIPTION
Hello, reviewers
When the input list is of size **run_local_at_count * 2 + 1**, it should ideally be divided into **two sublists**:

Sublist 1: **length = run_local_at_count**, should be processed by **sort_locally**.
Sublist 2: **length = run_local_at_count + 1**, should be processed by **merge_sort_remotely**.

However, due to an **error** in the splitting function, **both sublists are processed with sort_locally**, which deviates from the intended behavior of the algorithm. 

While the final sorted output is still correct, the process is not.

PS: I forget to use master branch to commit this file so I create this pull request again.